### PR TITLE
Fix typo in 01/Solution.ipynb [Closes #1]

### DIFF
--- a/aoc23/01/Solution.ipynb
+++ b/aoc23/01/Solution.ipynb
@@ -24,7 +24,7 @@
    "id": "574ea541",
    "metadata": {},
    "source": [
-    "From CUDA guid: \"They guide the programmer to partition the problem into coarse **sub-problems** that can be **solved independently in parallel by blocks of threads**, and **each sub-problem** into finer pieces that can be **solved cooperatively in parallel by all threads within the block.**\""
+    "From CUDA guide: \"They guide the programmer to partition the problem into coarse **sub-problems** that can be **solved independently in parallel by blocks of threads**, and **each sub-problem** into finer pieces that can be **solved cooperatively in parallel by all threads within the block.**\""
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the typo "guid" to "guide" in ``01/Solution.ipynb`` and closes #1.